### PR TITLE
PoC implementation of Ofy-based encryption

### DIFF
--- a/src/main/java/com/googlecode/objectify/ObjectifyFactory.java
+++ b/src/main/java/com/googlecode/objectify/ObjectifyFactory.java
@@ -6,6 +6,7 @@ import com.google.appengine.api.datastore.DatastoreServiceConfig;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.googlecode.objectify.cache.CachingAsyncDatastoreService;
 import com.googlecode.objectify.cache.EntityMemcache;
+import com.googlecode.objectify.encryption.EncryptionKeyStore;
 import com.googlecode.objectify.impl.CacheControlImpl;
 import com.googlecode.objectify.impl.EntityMemcacheStats;
 import com.googlecode.objectify.impl.EntityMetadata;
@@ -57,6 +58,9 @@ public class ObjectifyFactory implements Forge
 
 	/** Manages caching of entities at a low level */
 	protected EntityMemcache entityMemcache = new EntityMemcache(MEMCACHE_NAMESPACE, new CacheControlImpl(this), this.memcacheStats);
+
+	/** Supports lookups of encryption keys */
+	protected EncryptionKeyStore encryptionKeyStore;
 	
 	/**
 	 * <p>Construct an instance of the specified type.  Objectify uses this method whenever possible to create
@@ -321,5 +325,24 @@ public class ObjectifyFactory implements Forge
 	 */
 	public Keys keys() {
 		return keys;
+	}
+
+
+	/**
+	 * <p>Get the EncryptionKeyStore registered. This provides a set of keys to use for encrypting/decrypting properties
+	 * that have been annotated with @Serialize(encrypt=true)</p>
+	 * @return
+     */
+	public EncryptionKeyStore getEncryptionKeyStore() {
+		return this.encryptionKeyStore;
+	}
+
+	/**
+	 * Registers the EncryptionKeyStore to use to lookup encryption keys by key-id.
+	 *
+	 * @param encryptionKeyStore
+     */
+	public void setEncryptionKeyStore(EncryptionKeyStore encryptionKeyStore) {
+		this.encryptionKeyStore = encryptionKeyStore;
 	}
 }

--- a/src/main/java/com/googlecode/objectify/annotation/Serialize.java
+++ b/src/main/java/com/googlecode/objectify/annotation/Serialize.java
@@ -41,4 +41,20 @@ public @interface Serialize
 	 * If zip is true, sets the compression level of the Deflater.
 	 */
 	int compressionLevel() default Deflater.DEFAULT_COMPRESSION;
+
+
+	/**
+	 * If true and you've registered an EncryptionKeyStore on Objectify, the data stream will be encrypted using
+	 * AES 256-bit encryption.
+	 *
+	 *
+	 * Q: how should we implement migrating from encrypted --> unencrypted data?
+	 *
+	 * eg, with this, we can encrypt data by annotated fields w `@Serialize(encrypt=true)` and loading an saving everything
+	 * but there's no analogous way to elegantly decrypt data; that said, Ofy doesn't provide a simple method to move
+	 * from serialized --> unserialize data either I think; if you remove @Serialize annotation entirely, Ofy will
+	 * just choke on load, right?
+	 *
+     */
+	boolean encrypt() default false;
 }

--- a/src/main/java/com/googlecode/objectify/encryption/EncryptionKeyStore.java
+++ b/src/main/java/com/googlecode/objectify/encryption/EncryptionKeyStore.java
@@ -21,6 +21,9 @@ public interface EncryptionKeyStore {
      *
      * build keys w something like new SecretKeySpec(plainKey.getBytes(), "AES");
      *
+     * TODO: what if we want to rotate the Cipher approach?? should that be considered
+     * part of the key identity too?
+     *
      * @return
      */
     SortedMap<String, SecretKeySpec> getEncryptionKeys();

--- a/src/main/java/com/googlecode/objectify/encryption/EncryptionKeyStore.java
+++ b/src/main/java/com/googlecode/objectify/encryption/EncryptionKeyStore.java
@@ -1,0 +1,27 @@
+package com.googlecode.objectify.encryption;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.util.SortedMap;
+
+/**
+ * service through which to retrieve encryption keys
+ *
+ * @author Erik Schultink <erik@worklytics.co>
+ */
+public interface EncryptionKeyStore {
+
+    /**
+     * <p>sortedMap of encryption keys for keyId, in order of preference.
+     *
+     * on save, the first key will be used to encrypt data
+     *
+     * on load, Objectify will determine parse the hash of the key that data was encrypted with, and lookup the key's
+     * value from the Map<> by this hash.</p>
+     *
+     *
+     * build keys w something like new SecretKeySpec(plainKey.getBytes(), "AES");
+     *
+     * @return
+     */
+    SortedMap<String, SecretKeySpec> getEncryptionKeys();
+}

--- a/src/main/java/com/googlecode/objectify/impl/translate/SerializeTranslatorFactory.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/SerializeTranslatorFactory.java
@@ -2,15 +2,17 @@ package com.googlecode.objectify.impl.translate;
 
 import com.google.appengine.api.datastore.Blob;
 import com.googlecode.objectify.annotation.Serialize;
+import com.googlecode.objectify.encryption.EncryptionKeyStore;
 import com.googlecode.objectify.impl.Path;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
+import javax.crypto.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.*;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.SortedMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.Deflater;
@@ -27,6 +29,44 @@ public class SerializeTranslatorFactory implements TranslatorFactory<Object, Blo
 {
 	private static final Logger log = Logger.getLogger(SerializeTranslatorFactory.class.getName());
 
+
+	/**
+	 * wrapper class to wrap encrypted form of an arbitrary serialized value with meta-data needed for its decryption
+	 * (except for the actual encryption key itself, of course)
+	 *
+	 */
+	static final class EncryptedBlob implements Serializable {
+
+		// one of standard Java cipher implementations: https://docs.oracle.com/javase/7/docs/api/javax/crypto/Cipher.html
+
+		// Q: use an enum for this??
+		public static final String DEFAULT_CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
+
+		public static final long serialVersionUID = 1L;
+
+		// identifier for cipher used to encrypt this object, if any
+		String cipher = DEFAULT_CIPHER_TRANSFORMATION;
+
+		// identifier for encryption key used to encrypt this object, if any
+		// (used to support key rotation; eg, during rotation, will have mix of data encrypted using different keys)
+		String keyId = null;
+
+		//initialization vector used by encryption alg
+		byte[] iv;
+
+		//encrypted value; possibly compressed
+		byte[] encryptedValue;
+
+		static EncryptedBlob of(String cipher, String keyId, byte[] initializationVector, byte[] encryptedValue) {
+			EncryptedBlob blob = new EncryptedBlob();
+			blob.cipher = cipher;
+			blob.keyId = keyId;
+			blob.iv = initializationVector;
+			blob.encryptedValue = encryptedValue;
+			return blob;
+		}
+	}
+
 	@Override
 	public Translator<Object, Blob> create(TypeKey<Object> tk, CreateContext ctx, Path path) {
 		final Serialize serializeAnno = tk.getAnnotationAnywhere(Serialize.class);
@@ -35,16 +75,31 @@ public class SerializeTranslatorFactory implements TranslatorFactory<Object, Blo
 		if (serializeAnno == null)
 			return null;
 
+		final EncryptionKeyStore encryptionKeyStore = ctx.getFactory().getEncryptionKeyStore();
+
 		return new ValueTranslator<Object, Blob>(Blob.class) {
 			@Override
 			protected Object loadValue(Blob value, LoadContext ctx, Path path) throws SkipException {
+
+
 				// Need to be careful here because we don't really know if the data was serialized or not.  Start
 				// with whatever the annotation says, and if that doesn't work, try the other option.
 				try {
-					ByteArrayInputStream bais = new ByteArrayInputStream(value.getBytes());
 
 					// Start with the annotation
 					boolean unzip = serializeAnno.zip();
+
+					ByteArrayInputStream bais;
+
+
+					// data may or may not be encrypted; rely on inspecting the stored value, rather than the annotation
+					if (serializeAnno.encrypt()) {
+						bais = new ByteArrayInputStream(decrypt(value, ctx));
+					} else {
+						//can use it straight
+						bais = new ByteArrayInputStream(value.getBytes());
+					}
+
 					try {
 						return readObject(bais, unzip);
 					} catch (IOException ex) {	// will be one of ZipException or StreamCorruptedException
@@ -59,6 +114,7 @@ public class SerializeTranslatorFactory implements TranslatorFactory<Object, Blo
 					return null;	// never gets here
 				}
 			}
+
 
 			@Override
 			protected Blob saveValue(Object value, boolean index, SaveContext ctx, Path path) throws SkipException {
@@ -75,13 +131,62 @@ public class SerializeTranslatorFactory implements TranslatorFactory<Object, Blo
 					oos.writeObject(value);
 					oos.close();
 
-					return new Blob(baos.toByteArray());
+					byte[] bytes = baos.toByteArray();
+
+					if (serializeAnno.encrypt()) {
+						//attempt to encrypt
+						bytes = encrypt(baos.toByteArray());
+					}
+
+					return new Blob(bytes);
 
 				} catch (IOException ex) {
 					path.throwIllegalState("Unable to serialize " + value, ex);
 					return null;	// never gets here
 				}
 			}
+
+
+			/**
+			 * encrypt value
+			 */
+			private byte[] encrypt (byte[] input)  {
+				SortedMap<String, SecretKeySpec> keyMap = this.getKeyMap();
+
+				if (keyMap == null) {
+					return input;
+				} else {
+					SecretKeySpec key = keyMap.get(keyMap.firstKey());
+
+					//TODO: generate this at random to make secure; this is like salt; TBH, I'm unclear on exact distinction
+					byte[] ivBytes = "something-that-should-be-random".getBytes();
+
+					IvParameterSpec ivSpec = new IvParameterSpec(ivBytes);
+
+					try {
+						Cipher cipher = Cipher.getInstance(EncryptedBlob.DEFAULT_CIPHER_TRANSFORMATION);
+						cipher.init(Cipher.ENCRYPT_MODE, key, ivSpec);
+
+						byte[] encrypted = new byte[cipher.getOutputSize(input.length)];
+						int enc_len = cipher.update(input, 0, input.length, encrypted, 0);
+						cipher.doFinal(encrypted, enc_len);
+
+						//write encrypted blob
+						ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+						ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream);
+						EncryptedBlob encryptedBlob = EncryptedBlob.of(EncryptedBlob.DEFAULT_CIPHER_TRANSFORMATION, keyMap.firstKey(), ivBytes, encrypted);
+						objectOutputStream.writeObject(encryptedBlob);
+						objectOutputStream.close();
+						outputStream.close();
+
+						return outputStream.toByteArray();
+					} catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | ShortBufferException | IllegalBlockSizeException | BadPaddingException | InvalidAlgorithmParameterException | IOException e) {
+						log.log(Level.WARNING, "failed to encrypt", e);
+						return input;
+					}
+				}
+			}
+
 
 			/** Try reading an object from the stream */
 			private Object readObject(ByteArrayInputStream bais, boolean unzip) throws IOException, ClassNotFoundException {
@@ -94,6 +199,59 @@ public class SerializeTranslatorFactory implements TranslatorFactory<Object, Blo
 				ObjectInputStream ois = new ObjectInputStream(in);
 				return ois.readObject();
 			}
+
+
+			private SortedMap<String, SecretKeySpec> getKeyMap() {
+				if (encryptionKeyStore == null) {
+					log.log(Level.WARNING, "No EncryptionKeyStore registered");
+				} else {
+					return encryptionKeyStore.getEncryptionKeys();
+				}
+				return null;
+			}
+
+			/**
+			 * attempt to decrypt value
+             */
+			private byte[] decrypt (Blob value, LoadContext ctx)
+					throws NoSuchFieldException, IllegalAccessException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, ShortBufferException, BadPaddingException, IllegalBlockSizeException, IOException {
+
+				SortedMap<String, SecretKeySpec> keyMap = getKeyMap();
+				byte[] decrypted;
+				if (keyMap == null) {
+					log.log(Level.WARNING, "No keys to decrypt with");
+					return value.getBytes();
+				} else {
+
+					ObjectInputStream rawByteStream = new ObjectInputStream(new ByteArrayInputStream(value.getBytes()));
+
+					try {
+						EncryptedBlob encrypted = (EncryptedBlob) rawByteStream.readObject();
+
+						SecretKeySpec key = keyMap.get(encrypted.keyId);
+
+						if (key == null) {
+							//couldn't find key to use when decrypting this value;
+							throw new RuntimeException("Failed to decrypt value bc no key registered for id: " + encrypted.keyId);
+						}
+
+						IvParameterSpec ivSpec = new IvParameterSpec(encrypted.iv);
+						Cipher cipher = Cipher.getInstance(encrypted.cipher);
+						cipher.init(Cipher.DECRYPT_MODE, key, ivSpec);
+
+						decrypted = new byte[cipher.getOutputSize(value.getBytes().length)];
+
+						int dec_len = cipher.update(value.getBytes(), 0, value.getBytes().length, decrypted, 0);
+						cipher.doFinal(decrypted, dec_len);
+					} catch (IOException | ClassNotFoundException e) {
+						//assume it's NOT encrypted
+						decrypted = value.getBytes();
+					}
+					return decrypted;
+				}
+
+			}
+
 		};
 	}
 }

--- a/src/main/java/com/googlecode/objectify/impl/translate/SerializeTranslatorFactory.java
+++ b/src/main/java/com/googlecode/objectify/impl/translate/SerializeTranslatorFactory.java
@@ -213,7 +213,12 @@ public class SerializeTranslatorFactory implements TranslatorFactory<Object, Blo
 				if (fact.getEncryptionKeyStore() == null) {
 					log.log(Level.WARNING, "No EncryptionKeyStore registered");
 				} else {
-					return fact.getEncryptionKeyStore().getEncryptionKeys();
+					SortedMap<String, SecretKeySpec> keyMap = fact.getEncryptionKeyStore().getEncryptionKeys();
+					if (keyMap.isEmpty()) {
+						log.log(Level.WARNING, "EncryptionKeyStore did not provide any keys");
+					} else {
+						return keyMap;
+					}
 				}
 				return null;
 			}

--- a/src/test/java/com/googlecode/objectify/test/SerializeTests.java
+++ b/src/test/java/com/googlecode/objectify/test/SerializeTests.java
@@ -1,16 +1,17 @@
 package com.googlecode.objectify.test;
 
+import com.google.common.io.BaseEncoding;
 import com.googlecode.objectify.annotation.Cache;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Serialize;
+import com.googlecode.objectify.encryption.EncryptionKeyStore;
 import com.googlecode.objectify.test.util.TestBase;
 import com.googlecode.objectify.test.util.TestObjectifyFactory;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.*;
 
 import static com.googlecode.objectify.test.util.TestObjectifyService.fact;
 import static com.googlecode.objectify.test.util.TestObjectifyService.ofy;
@@ -124,4 +125,68 @@ public class SerializeTests extends TestBase
 		HasSerializeZip fetched = fact2.begin().load().type(HasSerializeZip.class).id(hs.id).now();
 		assert fetched.numbers.equals(hs.numbers);
 	}
+
+	/**
+	 * Serialize with Encryption tests
+	 */
+	public static EncryptionKeyStore mockKeyStore() {
+
+		//NOTE: java default env settings prohibit keys >128 bits
+		final byte[] AES_128_KEY = BaseEncoding.base64().decode("05B384DDDBD99FF6A0B100");
+
+		return new EncryptionKeyStore() {
+			@Override
+			public SortedMap<String, SecretKeySpec> getEncryptionKeys() {
+				SortedMap<String, SecretKeySpec> map = new TreeMap<>();
+				map.put("key1", new SecretKeySpec(AES_128_KEY, "AES"));
+				return map;
+			}
+		};
+	}
+
+	@Entity(name="HasSerialize")
+	@Cache
+	public static class HasSerializeEncrypt
+	{
+		@Id public Long id;
+		@Serialize(encrypt=true) public Map<Long, Long> numbers = new HashMap<>();
+	}
+
+	@Test
+	public void testSerializeAndEncrypt() {
+		fact().setEncryptionKeyStore(mockKeyStore());
+		fact().register(HasSerializeEncrypt.class);
+
+		HasSerializeEncrypt hs = new HasSerializeEncrypt();
+		hs.numbers.put(1L, 2L);
+		hs.numbers.put(3L, 4L);
+
+		ofy().save().entity(hs).now();
+
+		TestObjectifyFactory fact2 = new TestObjectifyFactory();
+		fact2.setEncryptionKeyStore(mockKeyStore());
+		fact2.register(HasSerializeEncrypt.class);
+
+		HasSerializeEncrypt fetched = fact2.begin().load().type(HasSerializeEncrypt.class).id(hs.id).now();
+		assert fetched.numbers.equals(hs.numbers);
+	}
+
+	@Test
+	public void testDeserializeLegacyUnencrypted() {
+		fact().register(HasSerialize.class);
+
+		HasSerialize hs = new HasSerialize();
+		hs.numbers.put(1L, 2L);
+		hs.numbers.put(3L, 4L);
+
+		ofy().save().entity(hs).now();
+
+		TestObjectifyFactory fact2 = new TestObjectifyFactory();
+		fact2.setEncryptionKeyStore(mockKeyStore());
+		fact2.register(HasSerializeEncrypt.class);
+
+		HasSerializeEncrypt fetched = fact2.begin().load().type(HasSerializeEncrypt.class).id(hs.id).now();
+		assert fetched.numbers.equals(hs.numbers);
+	}
+
 }


### PR DESCRIPTION
@jlorper for discussion purposes - not to be merged yet. (PR is from our fork anyways)

What I like about doing this via Ofy` @Serialize`:
  * clean - we just flip flag in one place everywhere we want to start encrypting stuff. 
  * as anything that to be encrypted must necessarily be serialized anyways, seems natural to provide it as an option on `@Serialize` flag. 
  * migrating to/from encrypted data is similar to other schema changes.
  * doing this at property-level gives flexibility to have mixed objects,

What I don't like about doing it this way:
  * maintaining our own Ofy fork (although this doesn't seem like an unreasonable thing for them to merge at some point; it's backwards compatible with their API)
  * more complicated to reason about what is/isn't encrypted, vs an approach that just encrypted everything (although I don't think that's ever possible unless we leave GAE datastore, or at least the indexes)


